### PR TITLE
Refactor plugin scanner + add support to ignore inline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Lint & Test PHP Project
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   quality-checks:

--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ Example: .distignore
 
 > These paths will be excluded from compatibility checks. This helps avoid false positives caused by test or development files.
 
+### 📝 Inline Ignore
+
+You can ignore specific lines from the scan by adding a special inline comment.
+
+This is useful when you conditionally use a newer function but know it’s safe, like:
+
+```php
+if (function_exists('wp_some_new_func')) {
+    return wp_some_new_func(); // @wp-since ignore
+}
+```
+
+> Only inline comments on the same line will be considered — comments above the line won’t trigger ignores.
+
 ## 🛠️ Coming Soon
 
 -   GitHub Action integration

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,6 +11,7 @@
 
   <!-- To ignore -->
   <exclude-pattern>vendor/*</exclude-pattern>
+  <exclude-pattern>tests/fixtures/*</exclude-pattern>
 
   <arg name="report-width" value="120"/>
 </ruleset>

--- a/src/Resolver/InlineIgnoreResolver.php
+++ b/src/Resolver/InlineIgnoreResolver.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WP_Since\Resolver;
+
+use PhpParser\Lexer\Emulative;
+
+class InlineIgnoreResolver
+{
+    public static function extractIgnoredLines(string $code): array
+    {
+        $lexer = new Emulative(['usedAttributes' => ['startLine']]);
+        $lexer->startLexing($code);
+
+        $ignoredLines = [];
+
+        foreach ($lexer->getTokens() as $token) {
+            if (is_array($token) && in_array($token[0], [T_COMMENT, T_DOC_COMMENT], true)) {
+                if (strpos($token[1], '@wp-since ignore') !== false) {
+                    $ignoredLines[] = $token[2];
+                }
+            }
+        }
+
+        return $ignoredLines;
+    }
+}

--- a/src/Scanner/PluginScanner.php
+++ b/src/Scanner/PluginScanner.php
@@ -2,12 +2,11 @@
 
 namespace WP_Since\Scanner;
 
-use PhpParser\Node;
 use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitorAbstract;
 use PhpParser\ParserFactory;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use WP_Since\Resolver\IgnoreRulesResolver;
+use WP_Since\Scanner\SymbolExtractorVisitor;
 
 class PluginScanner
 {
@@ -20,61 +19,7 @@ class PluginScanner
         $varMap = [];
 
         $traverser->addVisitor(new ParentConnectingVisitor());
-        $traverser->addVisitor(new class ($usedSymbols, $varMap) extends NodeVisitorAbstract {
-            private $usedSymbols;
-            private $varMap;
-
-            public function __construct(&$usedSymbols, &$varMap)
-            {
-                $this->usedSymbols = &$usedSymbols;
-                $this->varMap = &$varMap;
-            }
-
-            public function enterNode(Node $node)
-            {
-                if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
-                    $this->usedSymbols[] = (string)$node->name;
-
-                    if (in_array((string)$node->name, ['do_action', 'apply_filters'], true)) {
-                        $hookNameNode = $node->args[0]->value ?? null;
-                        if ($hookNameNode instanceof Node\Scalar\String_) {
-                            $this->usedSymbols[] = $hookNameNode->value;
-                        }
-                    }
-                } elseif ($node instanceof Node\Expr\New_ && $node->class instanceof Node\Name) {
-                    $this->usedSymbols[] = (string)$node->class;
-
-                    if (
-                        $node->getAttribute('parent') instanceof Node\Expr\Assign &&
-                        $node->getAttribute('parent')->var instanceof Node\Expr\Variable
-                    ) {
-                        $varName = $node->getAttribute('parent')->var->name;
-                        if (is_string($varName)) {
-                            $this->varMap[$varName] = (string)$node->class;
-                        }
-                    }
-                } elseif (
-                    $node instanceof Node\Expr\StaticCall &&
-                    $node->class instanceof Node\Name &&
-                    $node->name instanceof Node\Identifier
-                ) {
-                    $class = (string)$node->class;
-                    $method = (string)$node->name;
-                    $this->usedSymbols[] = "$class::$method";
-                } elseif (
-                    $node instanceof Node\Expr\MethodCall &&
-                    $node->var instanceof Node\Expr\Variable &&
-                    $node->name instanceof Node\Identifier
-                ) {
-                    $varName = $node->var->name;
-                    $method = (string)$node->name;
-                    if (is_string($varName) && isset($this->varMap[$varName])) {
-                        $class = $this->varMap[$varName];
-                        $this->usedSymbols[] = "$class::$method";
-                    }
-                }
-            }
-        });
+        $traverser->addVisitor(new SymbolExtractorVisitor($usedSymbols, $varMap));
 
         $ignorePaths = IgnoreRulesResolver::getIgnoredPaths($path);
         $rii = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path));

--- a/src/Scanner/SymbolExtractorVisitor.php
+++ b/src/Scanner/SymbolExtractorVisitor.php
@@ -10,14 +10,16 @@ class SymbolExtractorVisitor extends NodeVisitorAbstract
 {
     private array $usedSymbols;
     private array $varMap;
+    private array $ignoredLines;
 
     /** @var SymbolHandlerInterface[] */
     private array $handlers;
 
-    public function __construct(array &$usedSymbols, array &$varMap)
+    public function __construct(array &$usedSymbols, array &$varMap, array $ignoredLines = [])
     {
         $this->usedSymbols = &$usedSymbols;
         $this->varMap = &$varMap;
+        $this->ignoredLines = $ignoredLines;
 
         $this->handlers = [
             new SymbolHandlers\FunctionCallHandler(),
@@ -29,6 +31,10 @@ class SymbolExtractorVisitor extends NodeVisitorAbstract
 
     public function enterNode(Node $node)
     {
+        if (in_array($node->getStartLine(), $this->ignoredLines, true)) {
+            return null;
+        }
+
         foreach ($this->handlers as $handler) {
             if ($handler->supports($node)) {
                 $symbols = $handler->extract($node, $this->varMap);

--- a/src/Scanner/SymbolExtractorVisitor.php
+++ b/src/Scanner/SymbolExtractorVisitor.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WP_Since\Scanner;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use WP_Since\Scanner\SymbolHandlers\SymbolHandlerInterface;
+
+class SymbolExtractorVisitor extends NodeVisitorAbstract
+{
+    private array $usedSymbols;
+    private array $varMap;
+
+    /** @var SymbolHandlerInterface[] */
+    private array $handlers;
+
+    public function __construct(array &$usedSymbols, array &$varMap)
+    {
+        $this->usedSymbols = &$usedSymbols;
+        $this->varMap = &$varMap;
+
+        $this->handlers = [
+            new SymbolHandlers\FunctionCallHandler(),
+            new SymbolHandlers\NewClassHandler(),
+            new SymbolHandlers\StaticCallHandler(),
+            new SymbolHandlers\MethodCallHandler(),
+        ];
+    }
+
+    public function enterNode(Node $node)
+    {
+        foreach ($this->handlers as $handler) {
+            if ($handler->supports($node)) {
+                $symbols = $handler->extract($node, $this->varMap);
+                foreach ($symbols as $symbol) {
+                    $this->usedSymbols[] = $symbol;
+                }
+                break;
+            }
+        }
+    }
+}

--- a/src/Scanner/SymbolHandlers/FunctionCallHandler.php
+++ b/src/Scanner/SymbolHandlers/FunctionCallHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WP_Since\Scanner\SymbolHandlers;
+
+use PhpParser\Node;
+
+class FunctionCallHandler implements SymbolHandlerInterface
+{
+    public function supports(Node $node): bool
+    {
+        return $node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name;
+    }
+
+    public function extract(Node $node, array &$varMap = []): array
+    {
+        $symbols = [(string) $node->name];
+
+        if (in_array((string) $node->name, ['do_action', 'apply_filters'], true)) {
+            $hookNameNode = $node->args[0]->value ?? null;
+            if ($hookNameNode instanceof Node\Scalar\String_) {
+                $symbols[] = $hookNameNode->value;
+            }
+        }
+
+        return $symbols;
+    }
+}

--- a/src/Scanner/SymbolHandlers/MethodCallHandler.php
+++ b/src/Scanner/SymbolHandlers/MethodCallHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WP_Since\Scanner\SymbolHandlers;
+
+use PhpParser\Node;
+
+class MethodCallHandler implements SymbolHandlerInterface
+{
+    public function supports(Node $node): bool
+    {
+        return $node instanceof Node\Expr\MethodCall &&
+            $node->var instanceof Node\Expr\Variable &&
+            $node->name instanceof Node\Identifier;
+    }
+
+    public function extract(Node $node, array &$varMap = []): array
+    {
+        $varName = $node->var->name;
+        $method = (string) $node->name;
+
+        if (is_string($varName) && isset($varMap[$varName])) {
+            $class = $varMap[$varName];
+            return ["$class::$method"];
+        }
+
+        return [];
+    }
+}

--- a/src/Scanner/SymbolHandlers/NewClassHandler.php
+++ b/src/Scanner/SymbolHandlers/NewClassHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WP_Since\Scanner\SymbolHandlers;
+
+use PhpParser\Node;
+
+class NewClassHandler implements SymbolHandlerInterface
+{
+    public function supports(Node $node): bool
+    {
+        return $node instanceof Node\Expr\New_ && $node->class instanceof Node\Name;
+    }
+
+    public function extract(Node $node, array &$varMap = []): array
+    {
+        $symbols = [(string) $node->class];
+
+        $parent = $node->getAttribute('parent');
+        if (
+            $parent instanceof Node\Expr\Assign &&
+            $parent->var instanceof Node\Expr\Variable &&
+            is_string($parent->var->name)
+        ) {
+            $varMap[$parent->var->name] = (string) $node->class;
+        }
+
+        return $symbols;
+    }
+}

--- a/src/Scanner/SymbolHandlers/StaticCallHandler.php
+++ b/src/Scanner/SymbolHandlers/StaticCallHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WP_Since\Scanner\SymbolHandlers;
+
+use PhpParser\Node;
+
+class StaticCallHandler implements SymbolHandlerInterface
+{
+    public function supports(Node $node): bool
+    {
+        return $node instanceof Node\Expr\StaticCall &&
+            $node->class instanceof Node\Name &&
+            $node->name instanceof Node\Identifier;
+    }
+
+    public function extract(Node $node, array &$varMap = []): array
+    {
+        $class = (string) $node->class;
+        $method = (string) $node->name;
+        return ["$class::$method"];
+    }
+}

--- a/src/Scanner/SymbolHandlers/SymbolHandlerInterface.php
+++ b/src/Scanner/SymbolHandlers/SymbolHandlerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace WP_Since\Scanner\SymbolHandlers;
+
+use PhpParser\Node;
+
+interface SymbolHandlerInterface
+{
+    public function supports(Node $node): bool;
+
+    /**
+     * @return string[] Symbols extracted from the node
+     */
+    public function extract(Node $node, array &$varMap = []): array;
+}

--- a/tests/PluginScannerTest.php
+++ b/tests/PluginScannerTest.php
@@ -31,10 +31,10 @@ final class PluginScannerTest extends TestCase
         $path = __DIR__ . '/fixtures/plugin-ignore-comment';
         $symbols = PluginScanner::scan($path);
 
-        $this->assertNotContains('add_option', $symbols, 'Should ignore symbol marked with @wp-since ignore');
-        $this->assertNotContains('should_be_ignored', $symbols, 'Should ignore symbol marked with @wp-since ignore');
-        $this->assertNotContains('wp_is_block_theme', $symbols, 'Should ignore symbol marked with @wp-since ignore');
-        $this->assertNotContains('should_be_ignored_space', $symbols, 'Should ignore symbol marked with @wp-since ignore');
+        $this->assertNotContains('add_option', $symbols, 'Should ignore symbol with @wp-since ignore');
+        $this->assertNotContains('should_be_ignored', $symbols, 'Should ignore symbolwith @wp-since ignore');
+        $this->assertNotContains('wp_is_block_theme', $symbols, 'Should ignore symbol with @wp-since ignore');
+        $this->assertNotContains('should_be_ignored_space', $symbols, 'Should ignore symbol with @wp-since ignore');
         $this->assertContains('do_action', $symbols, 'Should detect function call without ignore comment');
         $this->assertContains('my_custom_hook', $symbols, 'Should detect function call without ignore comment');
         $this->assertContains('register_setting', $symbols, 'Should detect function call without ignore comment');

--- a/tests/PluginScannerTest.php
+++ b/tests/PluginScannerTest.php
@@ -25,4 +25,20 @@ final class PluginScannerTest extends TestCase
             $this->assertContains($symbol, $symbols, "Missing: $symbol");
         }
     }
+
+    public function testIgnoresSymbolsMarkedWithIgnoreComment()
+    {
+        $path = __DIR__ . '/fixtures/plugin-ignore-comment';
+        $symbols = PluginScanner::scan($path);
+
+        $this->assertNotContains('add_option', $symbols, 'Should ignore symbol marked with @wp-since ignore');
+        $this->assertNotContains('should_be_ignored', $symbols, 'Should ignore symbol marked with @wp-since ignore');
+        $this->assertNotContains('wp_is_block_theme', $symbols, 'Should ignore symbol marked with @wp-since ignore');
+        $this->assertNotContains('should_be_ignored_space', $symbols, 'Should ignore symbol marked with @wp-since ignore');
+        $this->assertContains('do_action', $symbols, 'Should detect function call without ignore comment');
+        $this->assertContains('my_custom_hook', $symbols, 'Should detect function call without ignore comment');
+        $this->assertContains('register_setting', $symbols, 'Should detect function call without ignore comment');
+        $this->assertContains('wp_detected_function', $symbols, 'Should detect function call without ignore comment');
+        $this->assertContains('need_detect', $symbols, 'Should detect function call without ignore comment');
+    }
 }

--- a/tests/fixtures/plugin-ignore-comment/plugin-ignore-comment.php
+++ b/tests/fixtures/plugin-ignore-comment/plugin-ignore-comment.php
@@ -1,0 +1,29 @@
+<?php
+
+add_option('should_be_ignored'); // @wp-since ignore
+
+do_action('should_be_ignored_space');     // @wp-since ignore
+
+do_action('need_detect'); // simple comment
+
+do_action('my_custom_hook');
+
+register_setting('mygroup', 'myoption');
+
+function isBlockTheme()
+{
+    if (function_exists( 'wp_is_block_theme')) {
+        return wp_is_block_theme(); // @wp-since ignore
+    }
+
+    return false;
+}
+
+function exampleWithoutIgnore()
+{
+    if (function_exists('wp_detected_function')) {
+        return wp_detected_function();
+    }
+
+    return false;
+}


### PR DESCRIPTION
This pull request introduces functionality to support inline ignore comments (`@wp-since ignore`) in the code scanning process. It refactors the symbol extraction logic into modular handlers and updates the scanning process to respect these inline ignore comments. Additionally, it includes new tests to verify the behavior of the changes.

### Inline Ignore Comments Support:
* Added documentation in `README.md` explaining how to use the `@wp-since ignore` inline comment to exclude specific lines from scans.
* Implemented the `InlineIgnoreResolver` class to detect and extract lines marked with `@wp-since ignore` from the code.

### Refactoring Symbol Extraction:
* Replaced the inline anonymous visitor in `PluginScanner` with a new `SymbolExtractorVisitor` class, which delegates symbol extraction to modular handlers. [[1]](diffhunk://#diff-1c7589c076cf72f4a26e211d88137fab1dd130d463607fef64b7e1ce5cb256aeL23-L77) [[2]](diffhunk://#diff-57c3f063f3cf49596e8e47e3f30088b57a92f5abf7fdd5d94f7bf3b1f568c34eR1-R48)
* Introduced individual symbol handlers (`FunctionCallHandler`, `MethodCallHandler`, `NewClassHandler`, `StaticCallHandler`) to handle specific types of symbols. These handlers implement a new `SymbolHandlerInterface`. [[1]](diffhunk://#diff-58f7db34e83c5b22189183c86c3becd37600ba9f0e546e3efdbd3c04a33868d5R1-R27) [[2]](diffhunk://#diff-3ab3b436cb9faa04d3627029d4105dee60d6f59e5adae9324ac6e57ee7241a6bR1-R28) [[3]](diffhunk://#diff-4e63bc83c43ebc41f2a37c41eb707457ade1c94b67a86ed8be26bf7a92ecb767R1-R29) [[4]](diffhunk://#diff-1f480f382382bf2fe1d4dfbd9be2672c39e21b6a2e31c680291d307a8ca373f7R1-R22) [[5]](diffhunk://#diff-86aff192b4da82c8adc16332a622a7ddc6ecf0a1ba09eeefecdc84b2a4921048R1-R15)

### Test Enhancements:
* Added a new test method, `testIgnoresSymbolsMarkedWithIgnoreComment`, in `PluginScannerTest` to verify that symbols marked with `@wp-since ignore` are excluded from the scan results.
* Created a test fixture (`plugin-ignore-comment.php`) to provide sample code for testing inline ignore functionality.