### PR TITLE
Add support for minimum wp version flag

### DIFF
--- a/bin/wp-since
+++ b/bin/wp-since
@@ -10,12 +10,33 @@ foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php
 
 use WP_Since\Runner\PluginCheckCommand;
 
-if ($argc < 2 || $argv[1] !== 'check') {
-    echo "🛠 Usage: wp-since check /path/to/plugin\n";
+// Manual argument parsing to handle options regardless of position.
+$command      = null;
+$pluginPath   = null;
+$minWpVersion = null;
+
+for ($i = 1; $i < count($argv); $i++) {
+    $arg = $argv[$i];
+    
+    if (strpos($arg, '--min-wp-version=') === 0) {
+        $minWpVersion = substr($arg, strlen('--min-wp-version='));
+    } elseif ($arg === '--min-wp-version' && isset($argv[$i + 1])) {
+        $minWpVersion = $argv[++$i];
+    } elseif ($arg === 'check') {
+        $command = $arg;
+    } elseif ($command === 'check' && $pluginPath === null) {
+        $pluginPath = $arg;
+    }
+}
+
+if ($command !== 'check') {
+    echo "🛠 Usage: wp-since check [--min-version=X.X.X] /path/to/plugin\n";
+    echo "   Options:\n";
+    echo "   --min-wp-version=X.X.X  Manually specify the minimum WordPress version\n";
     exit(0);
 }
 
-$pluginPath = $argv[2] ?? getcwd();
+$pluginPath   = $pluginPath ?? getcwd();
 $sinceMapPath = __DIR__ . '/../wp-since.json';
 
-exit(PluginCheckCommand::run($pluginPath, $sinceMapPath));
+exit(PluginCheckCommand::run($pluginPath, $sinceMapPath, $minWpVersion));

--- a/src/Runner/PluginCheckCommand.php
+++ b/src/Runner/PluginCheckCommand.php
@@ -10,21 +10,23 @@ use WP_Since\Utils\VersionHelper;
 
 class PluginCheckCommand
 {
-    public static function run(string $pluginPath, string $sinceMapPath): int
+    public static function run(string $pluginPath, string $sinceMapPath, ?string $minWpVersion = null): int
     {
         if (!file_exists($sinceMapPath)) {
             echo "❌ wp-since.json not found. Run composer generate-since first.\n";
             return 1;
         }
 
-        $versionResolver = VersionResolver::resolve($pluginPath);
-        if (!$versionResolver['version']) {
-            echo "❌ Could not determine the minimum required WP version.\n";
-            return 1;
+        if (! $minWpVersion) {
+            $versionResolver = VersionResolver::resolve($pluginPath);
+            if (!$versionResolver || !$versionResolver['version']) {
+                echo "❌ Could not determine the minimum required WP version.\n";
+                return 1;
+            }
         }
 
-        $source = $versionResolver['source'] ?? '';
-        $declaredVersion = $versionResolver['version'];
+        $source          = $minWpVersion ? 'argument' : $versionResolver['source'] ?? '';
+        $declaredVersion = $minWpVersion ?? $versionResolver['version'];
 
         echo "✅ Minimum version declared: {$declaredVersion} (from {$source})\n\n";
 


### PR DESCRIPTION
Closes #15 

This PR adds support for manually specifying the minimum WP version through a command arg/flag. This is useful for plugins that do not have a readme because they are not listed on WordPress.org.

This can also be beneficial for testing purposes (e.g. when planning to increase the minimum WP version).

**Testing instructions**

1. Run the command like this and verify that it correctly uses the version passed as an arg - `./vendor/bin/wp-since check --min-wp-version=6.0 <some-dir-path>`
2. Run the command without the flag and verify that it still correctly extracts the min WP version from the readme = `./vendor/bin/wp-since check <some-dir-path>