### PR TITLE
Fix: anonymous classes skip in generate command

### DIFF
--- a/generate-since-json.php
+++ b/generate-since-json.php
@@ -59,6 +59,9 @@ class SinceExtractor extends NodeVisitorAbstract
         if ($node instanceof Node\Stmt\Function_) {
             $this->addResult($node->name->toString(), 'function', $since, $deprecated);
         } elseif ($node instanceof Node\Stmt\Class_ || $node instanceof Node\Stmt\Interface_ || $node instanceof Node\Stmt\Trait_) {
+            if ($node->name === null) {
+                return; // Skip anonymous classes
+            }
             $type = $node instanceof Node\Stmt\Class_ ? 'class' : ($node instanceof Node\Stmt\Interface_ ? 'interface' : 'trait');
             $this->addResult($node->name->toString(), $type, $since, $deprecated);
         } elseif ($node instanceof Node\Stmt\ClassMethod && !$node->isPrivate()) {


### PR DESCRIPTION
This pull request makes a small but important change to the `generate-since-json.php` script. The update ensures that anonymous classes are skipped during processing, preventing potential issues with unnamed class nodes.

* Anonymous classes are now detected and skipped in the `enterNode` method to avoid adding unnamed classes to the results.