### PR TITLE
fix: resolve minimum WP version from plugin header more reliably

### DIFF
--- a/src/Resolver/VersionResolver.php
+++ b/src/Resolver/VersionResolver.php
@@ -4,12 +4,13 @@ namespace WP_Since\Resolver;
 
 class VersionResolver
 {
+    private const HEADER_BYTES = 8192;
+
     public static function resolve(string $pluginPath): ?array
     {
         $pluginFile = self::findMainPluginFile($pluginPath);
-
         if ($pluginFile) {
-            $version = self::extractVersionFromPluginHeader($pluginFile);
+            $version = self::extractRequiresAtLeast(self::readFileHeader($pluginFile));
             if ($version) {
                 return ['version' => $version, 'source' => 'main plugin file header'];
             }
@@ -17,7 +18,7 @@ class VersionResolver
 
         $readme = self::findReadmeFile($pluginPath);
         if ($readme) {
-            $version = self::extractVersionFromReadme($readme);
+            $version = self::extractRequiresAtLeast(self::readFileHeader($readme));
             if ($version) {
                 return ['version' => $version, 'source' => 'readme'];
             }
@@ -28,24 +29,10 @@ class VersionResolver
 
     private static function findMainPluginFile(string $pluginPath): ?string
     {
-        $basename = basename($pluginPath);
-        $candidate = "{$pluginPath}/{$basename}.php";
-        if (file_exists($candidate)) {
-            return $candidate;
-        }
-
-        return null;
-    }
-
-    private static function extractVersionFromPluginHeader(string $file): ?string
-    {
-        $contents = file_get_contents($file);
-        if (!$contents) {
-            return null;
-        }
-
-        if (preg_match('/^\s*\*\s+Requires at least:\s*([0-9.]+)/mi', $contents, $matches)) {
-            return $matches[1];
+        foreach (glob("{$pluginPath}/*.php") ?: [] as $file) {
+            if (stripos(self::readFileHeader($file), 'Plugin Name:') !== false) {
+                return $file;
+            }
         }
 
         return null;
@@ -59,19 +46,29 @@ class VersionResolver
                 return $full;
             }
         }
+
         return null;
     }
 
-    private static function extractVersionFromReadme(string $file): ?string
+    private static function extractRequiresAtLeast(string $contents): ?string
     {
-        $lines = file($file);
-        foreach ($lines as $line) {
-            if (stripos($line, 'Requires at least:') === 0) {
-                if (preg_match('/Requires at least:\s*([0-9.]+)/i', $line, $matches)) {
-                    return $matches[1];
-                }
-            }
+        if (preg_match('/^(?:[ \t]*<\?php)?[ \t\/*#@]*Requires at least:\s*([0-9.]+)/mi', $contents, $matches)) {
+            return $matches[1];
         }
+
         return null;
+    }
+
+    private static function readFileHeader(string $file): string
+    {
+        $handle = fopen($file, 'rb');
+        if (!$handle) {
+            return '';
+        }
+
+        $data = fread($handle, self::HEADER_BYTES);
+        fclose($handle);
+
+        return $data ?: '';
     }
 }

--- a/tests/VersionResolverTest.php
+++ b/tests/VersionResolverTest.php
@@ -16,6 +16,24 @@ class VersionResolverTest extends TestCase
         $this->assertEquals('main plugin file header', $resolved['source']);
     }
 
+    public function testExtractsVersionWhenMainFileNameDiffersFromDirectory()
+    {
+        $path = __DIR__ . '/fixtures/plugin-custom-main-file';
+        $resolved = VersionResolver::resolve($path);
+
+        $this->assertEquals('6.4', $resolved['version']);
+        $this->assertEquals('main plugin file header', $resolved['source']);
+    }
+
+    public function testExtractsVersionFromHeaderWithoutPerLineAsterisks()
+    {
+        $path = __DIR__ . '/fixtures/plugin-bare-header';
+        $resolved = VersionResolver::resolve($path);
+
+        $this->assertEquals('6.1', $resolved['version']);
+        $this->assertEquals('main plugin file header', $resolved['source']);
+    }
+
     public function testExtractsVersionFromReadmeIfNoHeader()
     {
         $path = __DIR__ . '/fixtures/plugin-with-readme-only';

--- a/tests/fixtures/plugin-bare-header/plugin-bare-header.php
+++ b/tests/fixtures/plugin-bare-header/plugin-bare-header.php
@@ -1,0 +1,8 @@
+<?php
+/*
+Plugin Name: Bare Header Plugin
+Description: Header block without per-line asterisks.
+Version: 1.0
+Requires at least: 6.1
+Requires PHP: 7.4
+*/

--- a/tests/fixtures/plugin-custom-main-file/bootstrap.php
+++ b/tests/fixtures/plugin-custom-main-file/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Plugin Name: Custom Main File Plugin
+ * Description: Main file name differs from the directory name.
+ * Version: 1.0
+ * Requires at least: 6.4
+ * Requires PHP: 7.4
+ */


### PR DESCRIPTION
## Problem

Plugins without a `readme.txt` were failing with `❌ Could not determine the minimum required WP version`, even when their main file declared `Requires at least`. Reported in #18.

Two root causes in `VersionResolver`:

1. **The main file was only found when its name matched the directory.** `findMainPluginFile()` looked only for `{dir}/{dir}.php`, so premium plugins whose bootstrap file is named `plugin.php`, `main.php`, `bootstrap.php`, etc. were never read.
2. **The header regex required a `*` on every line.** It matched `/**\n * Requires at least: */` but not the equally valid bare `/* ... */` (or `#`) comment style — which WordPress core itself accepts.

Either one alone produced the "Could not determine" error when no `readme.txt` was present.

## Fix

- Find the main file by scanning top-level `*.php` for a `Plugin Name:` header — the same way WP core's `get_plugins()` identifies a plugin.
- Match `Requires at least` with the same pattern `get_file_data()` uses (`/^(?:[ \t]*<\?php)?[ \t\/*#@]*Requires at least:.../mi`), so every comment style WP supports is read. Detection now mirrors the platform instead of guessing.
- Read only the first 8KB of each file, like `get_file_data()`, avoiding false matches deeper in the code.
- Unify header/readme extraction into a single `extractRequiresAtLeast()` helper.

## Verification

| scenario | before | after |
| --- | --- | --- |
| main file `bootstrap.php`, no `readme.txt` | ❌ Could not determine | ✅ `6.4 (main plugin file header)` |
| bare `/* */` header (no per-line `*`) | ❌ Could not determine | ✅ `6.1 (main plugin file header)` |

- New fixtures + tests cover both scenarios; **17 tests pass**, `phpcs` clean.
- Confirmed end-to-end via `php bin/wp-since check` on both fixtures.

## Notes

Scope is plugins only. Theme (`style.css`) support from #18 is out of scope for this PR and is tracked separately in #24.

Refs #18
