### PR TITLE
fix: warn when a plugin file cannot be parsed instead of skipping it silently

### DIFF
--- a/src/Scanner/PluginScanner.php
+++ b/src/Scanner/PluginScanner.php
@@ -44,7 +44,7 @@ class PluginScanner
                 $stmts = $parser->parse($code);
                 $traverser->traverse($stmts);
             } catch (\Exception $e) {
-                // Add error handling
+                fwrite(STDERR, "⚠️  Skipped {$relativePath}: could not parse ({$e->getMessage()})\n");
             }
 
             $traverser->removeVisitor($visitor);

--- a/tests/PluginScannerTest.php
+++ b/tests/PluginScannerTest.php
@@ -28,6 +28,18 @@ final class PluginScannerTest extends TestCase
         }
     }
 
+    public function testContinuesScanningWhenAFileCannotBeParsed()
+    {
+        $path = __DIR__ . '/fixtures/plugin-with-parse-error';
+        $symbols = PluginScanner::scan($path);
+
+        $this->assertContains(
+            'hook:parse_error_survivor',
+            $symbols,
+            'Valid files must still be scanned when another file fails to parse'
+        );
+    }
+
     public function testIgnoresSymbolsMarkedWithIgnoreComment()
     {
         $path = __DIR__ . '/fixtures/plugin-ignore-comment';

--- a/tests/fixtures/plugin-with-parse-error/broken.php
+++ b/tests/fixtures/plugin-with-parse-error/broken.php
@@ -1,0 +1,5 @@
+<?php
+
+function broken_function( {
+    return true;
+}

--- a/tests/fixtures/plugin-with-parse-error/valid.php
+++ b/tests/fixtures/plugin-with-parse-error/valid.php
@@ -1,0 +1,3 @@
+<?php
+
+do_action('parse_error_survivor');


### PR DESCRIPTION
## Problem

When a plugin file failed to parse, `PluginScanner::scan()` caught the exception and did nothing (an empty `catch` with an `// Add error handling` TODO). The file's symbols were silently dropped, so the scan could still print `✅ All good!` even though part of the plugin was never analyzed — a false negative with no signal to the user.

## Fix

Emit a warning to **STDERR** naming the skipped file and the parse error, while keeping the resilient behavior of continuing with the remaining files. STDERR is used so the diagnostic doesn't pollute the report on STDOUT.

```php
} catch (\Exception $e) {
    fwrite(STDERR, "⚠️  Skipped {$relativePath}: could not parse ({$e->getMessage()})\n");
}
```

## Verification

Scanning a fixture with one broken and one valid file:

```
STDOUT: symbols collected: hook:parse_error_survivor
STDERR: ⚠️  Skipped broken.php: could not parse (Syntax error, unexpected '{', expecting T_VARIABLE on line 3)
```

- New fixture (`plugin-with-parse-error/`) + test asserting valid files are still scanned when another file fails to parse.
- **18 tests pass**, `phpcs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
