### PR TITLE
Chore: Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Worried about accidentally using functions or APIs that don’t exist in declare
     -   Classes
     -   Class methods (static and instance)
     -   Action and filter hooks
--   📖 Reads the declared Requires at least: version from your `readme.txt`
+-   📖 Reads the declared `Requires at least:` version from your plugin's main file header — or `readme.txt` if the header doesn't set it
 -   🗂️ Compares those symbols with a version map built from WordPress core using `@since` tags
 -   🚨 Reports any used symbols that require a newer WP version than what’s declared
 
@@ -31,27 +31,25 @@ Worried about accidentally using functions or APIs that don’t exist in declare
 Let’s say your plugin uses `register_setting()` (introduced in WP `5.5`), but your `readme.txt` declares compatibility with WordPress `5.4`:
 
 ```bash
-🔍 Scanning plugin files...
-✅ Found readme.txt → Minimum version declared: 5.4
+✅ Minimum version declared: 5.4 (from readme)
 
 🚨 Compatibility issues found:
 
-┌──────────────────────┬──────────────────┐
-│ Symbol               │ Introduced in WP │
-├──────────────────────┼──────────────────┤
-│ register_setting     │ 5.5.0            │
-└──────────────────────┴──────────────────┘
+┌─────────────────────────────┬──────────────────┐
+│ Symbol                      │ Introduced in WP │
+├─────────────────────────────┼──────────────────┤
+│ register_setting (function) │ 5.5.0            │
+└─────────────────────────────┴──────────────────┘
 
-📌 Suggested version required: 5.5.0
+📌 Suggested version required:  5.5.0
 ```
 
 Now imagine your code is fully aligned with your declared version:
 
 ```bash
-🔍 Scanning plugin files...
-✅ Found readme.txt → Minimum version declared: 5.5
+✅ Minimum version declared: 5.5 (from readme)
 
-🎉 No compatibility issues found!
+✅ All good! Your plugin is compatible with WP 5.5.
 ```
 
 Simple. Powerful. Automatic.  
@@ -74,6 +72,12 @@ composer require --dev eduardovillao/wp-since
 
 ```bash
 ./vendor/bin/wp-since check ./path-to-your-plugin
+```
+
+By default the minimum WordPress version is detected automatically from your plugin header or `readme.txt`. To override it, pass `--min-wp-version`:
+
+```bash
+./vendor/bin/wp-since check ./path-to-your-plugin --min-wp-version=6.0
 ```
 
 ### 🧹 Ignore Files & Folders

--- a/bin/wp-since
+++ b/bin/wp-since
@@ -30,7 +30,7 @@ for ($i = 1; $i < count($argv); $i++) {
 }
 
 if ($command !== 'check') {
-    echo "🛠 Usage: wp-since check [--min-version=X.X.X] /path/to/plugin\n";
+    echo "🛠 Usage: wp-since check [--min-wp-version=X.X.X] /path/to/plugin\n";
     echo "   Options:\n";
     echo "   --min-wp-version=X.X.X  Manually specify the minimum WordPress version\n";
     exit(0);


### PR DESCRIPTION
This pull request updates the `README.md` to clarify how the minimum required WordPress version is detected and to improve the accuracy and readability of usage examples. It also documents a new option for overriding the detected minimum version.

**Documentation improvements:**

* Clarified that the tool reads the `Requires at least:` version from the plugin's main file header first, or falls back to `readme.txt` if not set.
* Updated example output to match the new detection logic and improved clarity by specifying the symbol type (e.g., `register_setting (function)`) and simplifying messages for compatibility checks.

**New feature documentation:**

* Added instructions for overriding the automatically detected minimum WordPress version using the `--min-wp-version` flag in the CLI.